### PR TITLE
update vod-module to latest release 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache curl build-base openssl openssl-dev zlib-dev linux-header
 RUN mkdir nginx nginx-vod-module
 
 ARG NGINX_VERSION=1.16.1
-ARG VOD_MODULE_VERSION=2b36aea4f35bf9d302328c09b572980b78cf6fa8
+ARG VOD_MODULE_VERSION=399e1a0ecb5b0007df3a627fa8b03628fc922d5e
 
 RUN curl -sL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -C /nginx --strip 1 -xz
 RUN curl -sL https://github.com/kaltura/nginx-vod-module/archive/${VOD_MODULE_VERSION}.tar.gz | tar -C /nginx-vod-module --strip 1 -xz


### PR DESCRIPTION
I don't know if this will make a difference in our fragmented mp4 playback issues, but I figure it can't hurt to test.

It looks like they were tracking the `master` branch before, since the old hash `2b36aea` was after 1.24 but before 1.25.